### PR TITLE
Fix build release

### DIFF
--- a/0001-aspectd.patch
+++ b/0001-aspectd.patch
@@ -1,20 +1,20 @@
-From ae3fa866d428bcd96f8f88d2a973316b8be52038 Mon Sep 17 00:00:00 2001
-From: KyleWong <kang.wang1988@gmail.com>
-Date: Mon, 2 Nov 2020 15:08:40 +0800
-Subject: [PATCH] aspectd
+From 2805cd4b4dca3a064c78d3ad6799a25f8b7547ae Mon Sep 17 00:00:00 2001
+From: wangziyang <457155134@qq.com>
+Date: Thu, 5 Nov 2020 20:45:57 +0800
+Subject: [PATCH] for aspectd.patch
 
 ---
- packages/flutter_tools/lib/src/aspectd.dart   | 209 ++++++++++++++++++
+ packages/flutter_tools/lib/src/aspectd.dart   | 207 ++++++++++++++++++
  .../lib/src/build_system/targets/common.dart  |   9 +
- 2 files changed, 218 insertions(+)
+ 2 files changed, 216 insertions(+)
  create mode 100644 packages/flutter_tools/lib/src/aspectd.dart
 
 diff --git a/packages/flutter_tools/lib/src/aspectd.dart b/packages/flutter_tools/lib/src/aspectd.dart
 new file mode 100644
-index 0000000000..2203fb4b4f
+index 0000000000..4e412b2530
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aspectd.dart
-@@ -0,0 +1,209 @@
+@@ -0,0 +1,207 @@
 +// Copyright 2018 The Chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -192,8 +192,6 @@ index 0000000000..2203fb4b4f
 +        globals.fs.path.join(aspectdDir.path, '.dart_tool', 'flutter_build');
 +
 +    final Map<String, String> defines = environment.defines;
-+    relativeDir = defines[kTargetFile]
-+        .substring(environment.projectDir.absolute.path.length + 1);
 +    defines[kTargetFile] = globals.fs.path
 +        .join(aspectdDir.path, 'lib', aspectdImplPackageName + '.dart');
 +
@@ -230,14 +228,14 @@ index c4a8646110..aa71eee603 100644
 +++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
 @@ -5,6 +5,7 @@
  import 'package:package_config/package_config.dart';
- 
+
  import '../../artifacts.dart';
 +import '../../aspectd.dart';
  import '../../base/build.dart';
  import '../../base/file_system.dart';
  import '../../build_info.dart';
 @@ -193,6 +194,13 @@ class KernelSnapshot extends Target {
- 
+
    @override
    Future<void> build(Environment environment) async {
 +    await buildImpl(environment);
@@ -257,7 +255,7 @@ index c4a8646110..aa71eee603 100644
 +    return output;
    }
  }
- 
--- 
-2.24.3 (Apple Git-128)
+
+--
+2.24.2 (Apple Git-127)
 

--- a/0001-aspectd.patch
+++ b/0001-aspectd.patch
@@ -1,20 +1,20 @@
-From 2805cd4b4dca3a064c78d3ad6799a25f8b7547ae Mon Sep 17 00:00:00 2001
-From: wangziyang <457155134@qq.com>
-Date: Thu, 5 Nov 2020 20:45:57 +0800
-Subject: [PATCH] for aspectd.patch
+From ae3fa866d428bcd96f8f88d2a973316b8be52038 Mon Sep 17 00:00:00 2001
+From: KyleWong <kang.wang1988@gmail.com>
+Date: Mon, 2 Nov 2020 15:08:40 +0800
+Subject: [PATCH] aspectd
 
 ---
- packages/flutter_tools/lib/src/aspectd.dart   | 207 ++++++++++++++++++
+ packages/flutter_tools/lib/src/aspectd.dart   | 209 ++++++++++++++++++
  .../lib/src/build_system/targets/common.dart  |   9 +
- 2 files changed, 216 insertions(+)
+ 2 files changed, 218 insertions(+)
  create mode 100644 packages/flutter_tools/lib/src/aspectd.dart
 
 diff --git a/packages/flutter_tools/lib/src/aspectd.dart b/packages/flutter_tools/lib/src/aspectd.dart
 new file mode 100644
-index 0000000000..4e412b2530
+index 0000000000..2203fb4b4f
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aspectd.dart
-@@ -0,0 +1,207 @@
+@@ -0,0 +1,209 @@
 +// Copyright 2018 The Chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -192,6 +192,8 @@ index 0000000000..4e412b2530
 +        globals.fs.path.join(aspectdDir.path, '.dart_tool', 'flutter_build');
 +
 +    final Map<String, String> defines = environment.defines;
++    relativeDir = defines[kTargetFile]
++        .substring(environment.projectDir.absolute.path.length + 1);
 +    defines[kTargetFile] = globals.fs.path
 +        .join(aspectdDir.path, 'lib', aspectdImplPackageName + '.dart');
 +
@@ -228,14 +230,14 @@ index c4a8646110..aa71eee603 100644
 +++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
 @@ -5,6 +5,7 @@
  import 'package:package_config/package_config.dart';
-
+ 
  import '../../artifacts.dart';
 +import '../../aspectd.dart';
  import '../../base/build.dart';
  import '../../base/file_system.dart';
  import '../../build_info.dart';
 @@ -193,6 +194,13 @@ class KernelSnapshot extends Target {
-
+ 
    @override
    Future<void> build(Environment environment) async {
 +    await buildImpl(environment);
@@ -255,7 +257,7 @@ index c4a8646110..aa71eee603 100644
 +    return output;
    }
  }
-
---
-2.24.2 (Apple Git-127)
+ 
+-- 
+2.24.3 (Apple Git-128)
 

--- a/lib/src/transformer/aop/aop_utils.dart
+++ b/lib/src/transformer/aop/aop_utils.dart
@@ -468,7 +468,7 @@ class AopUtils {
         return const DynamicType();
       }
       return TypeParameterType(
-          deepCopyASTNode(node.parameter), deepCopyASTNode(node.promotedBound));
+          deepCopyASTNode(node.parameter), node.nullability,deepCopyASTNode(node.promotedBound));
     }
     if (node is FunctionType) {
       return FunctionType(

--- a/lib/src/transformer/aop/aspectd_aop_call_visitor.dart
+++ b/lib/src/transformer/aop/aspectd_aop_call_visitor.dart
@@ -329,10 +329,10 @@ class AspectdAopCallVisitor extends Transformer {
       Class pointCutClass, Class procedureImpl, Procedure originalProcedure) {
     //Add library dependency
     //Add new Procedure
-    final DirectMethodInvocation mockedInvocation = DirectMethodInvocation(
+    final MethodInvocation mockedInvocation = MethodInvocation(
         AsExpression(PropertyGet(ThisExpression(), Name('target')),
             InterfaceType(procedureImpl, Nullability.legacy)),
-        originalProcedure,
+        originalProcedure.name,
         AopUtils.concatArguments4PointcutStubCall(originalProcedure));
     final bool shouldReturn =
         !(originalProcedure.function.returnType is VoidType);

--- a/lib/src/transformer/aop/aspectd_aop_execute_visitor.dart
+++ b/lib/src/transformer/aop/aspectd_aop_execute_visitor.dart
@@ -191,10 +191,10 @@ class AspectdAopExecuteVisitor extends RecursiveVisitor<void> {
     final Class pointcutClass = AopUtils.pointCutProceedProcedure.parent;
     AopUtils.insertLibraryDependency(pointcutLibrary, originalLibrary);
 
-    final DirectMethodInvocation mockedInvocation = DirectMethodInvocation(
+    final MethodInvocation mockedInvocation = MethodInvocation(
         AsExpression(PropertyGet(ThisExpression(), Name('target')),
             InterfaceType(originalClass, Nullability.legacy)),
-        originalStubProcedure,
+        originalStubProcedure.name,
         AopUtils.concatArguments4PointcutStubCall(originalProcedure));
 
     final Procedure stubProcedureNew = AopUtils.createStubProcedure(


### PR DESCRIPTION
关于release下问题：

因为release 下是aot模式，会进行全局的静态分析（TFA），代码逻辑在：

```
//kernel_front_end.dart
Future<KernelCompilationResults> compileToKernel(
    Uri source, CompilerOptions options,
    {bool includePlatform: false,
    bool aot: false,
    bool useGlobalTypeFlowAnalysis: false,
    Map<String, String> environmentDefines,
    bool enableAsserts: true,
    bool genBytecode: false,
    BytecodeOptions bytecodeOptions,
    bool dropAST: false,
    bool useProtobufTreeShaker: false,
    bool useProtobufTreeShakerV2: false,
    bool minimalKernel: false,
    bool treeShakeWriteOnlyFields: false,
    String fromDillFile: null}) async {
     ...
       // Run global transformations only if component is correct.
       //debug下不执行，release下aot为true会执行
  if ((aot || minimalKernel) && component != null) {
    await runGlobalTransformations(
        options.target,
        component,
        useGlobalTypeFlowAnalysis,
        enableAsserts,
        useProtobufTreeShaker,
        useProtobufTreeShakerV2,
        errorDetector,
        minimalKernel: minimalKernel,
        treeShakeWriteOnlyFields: treeShakeWriteOnlyFields);
        ...
  }
     ...

}
```

比如，执行`flutter  build apk`命令，报错堆栈如下：

```
Invalid argument(s): Iterables do not have same length.                 
#0      MapBase._fillMapWithIterables (dart:collection/maps.dart:92:7)  
#1      new LinkedHashMap.fromIterables (dart:collection/linked_hash_map.dart:127:13)
#2      Substitution.fromPairs (package:kernel/type_algebra.dart:242:13)
#3      DirectMethodInvocation.getStaticType (package:kernel/ast.dart:3542:25)
#4      SummaryCollector._staticDartType (package:vm/transformations/type_flow/summary_collector.dart:1173:12)
#5      SummaryCollector._staticType (package:vm/transformations/type_flow/summary_collector.dart:1176:36)
#6      SummaryCollector._makeCall (package:vm/transformations/type_flow/summary_collector.dart:1080:26)
#7      SummaryCollector.visitDirectMethodInvocation (package:vm/transformations/type_flow/summary_collector.dart:1519:12)
#8      DirectMethodInvocation.accept (package:kernel/ast.dart:3528:44) 
#9      SummaryCollector._visit (package:vm/transformations/type_flow/summary_collector.dart:853:42)
#10     SummaryCollector.visitReturnStatement (package:vm/transformations/type_flow/summary_collector.dart:2058:37)
#11     ReturnStatement.accept (package:kernel/ast.dart:6541:43)        
#12     SummaryCollector._visit (package:vm/transformations/type_flow/summary_collector.dart:853:42)
#13     List.forEach (dart:core-patch/growable_array.dart:313:8)        
#14     SummaryCollector.visitBlock (package:vm/transformations/type_flow/summary_collector.dart:1923:21)
#15     Block.accept (package:kernel/ast.dart:5873:43)                  
#16     SummaryCollector._visit (package:vm/transformations/type_flow/summary_collector.dart:853:42)
#17     SummaryCollector.createSummary (package:vm/transformations/type_flow/summary_collector.dart:758:9)
#18     TypeFlowAnalysis.getSummary (package:vm/transformations/type_flow/analysis.dart:1451:52)
#19     _DirectInvocation._processFunction (package:vm/transformations/type_flow/analysis.dart:287:42)
#20     _DirectInvocation.process (package:vm/transformations/type_flow/analysis.dart:212:14)
#21     _WorkList.processInvocation (package:vm/transformations/type_flow/analysis.dart:1347:32)
#22     _DispatchableInvocation.process.<anonymous closure> (package:vm/transformations/type_flow/analysis.dart:437:44)
#23     _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:377:8)
#24     _DispatchableInvocation.process (package:vm/transformations/type_flow/analysis.dart:412:12)
#25     _WorkList.processInvocation (package:vm/transformations/type_flow/analysis.dart:1347:32)
#26     TypeFlowAnalysis.applyCall (package:vm/transformations/type_flow/analysis.dart:1581:23)
#27     Call.apply (package:vm/transformations/type_flow/summary.dart:265:31)
#28     Summary.apply (package:vm/transformations/type_flow/summary.dart:702:33)
#29     _DirectInvocation._processFunction (package:vm/transformations/type_flow/analysis.dart:296:24)
#30     _DirectInvocation.process (package:vm/transformations/type_flow/analysis.dart:212:14)
#31     _WorkList.processInvocation (package:vm/transformations/type_flow/analysis.dart:1347:32)
#32     _DispatchableInvocation.process.<anonymous closure> (package:vm/transformations/type_flow/analysis.dart:437:44)
#33     _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:377:8)
#34     _DispatchableInvocation.process (package:vm/transformations/type_flow/analysis.dart:412:12)
#35     _WorkList.processInvocation (package:vm/transformations/type_flow/analysis.dart:1347:32)
#36     TypeFlowAnalysis.applyCall (package:vm/transformations/type_flow/analysis.dart:1581:23)
#37     Call.apply (package:vm/transformations/type_flow/summary.dart:265:31)
#38     Summary.apply (package:vm/transformations/type_flow/summary.dart:702:33)
#39     _DirectInvocation._processFunction (package:vm/transformations/type_flow/analysis.dart:296:24)
#40     _DirectInvocation.process (package:vm/transformations/type_flow/analysis.dart:212:14)
#41     _WorkList.processInvocation (package:vm/transformations/type_flow/analysis.dart:1347:32)
#42     _DispatchableInvocation.process.<anonymous closure> (package:vm/transformations/type_flow/analysis.dart:437:44)
#43     _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:377:8)
#44     _DispatchableInvocation.process (package:vm/transformations/type_flow/analysis.dart:412:12)
#45     _WorkList.processInvocation (package:vm/transformations/type_flow/analysis.dart:1347:32)
#46     _WorkList.process (package:vm/transformations/type_flow/analysis.dart:1290:7)
#47     TypeFlowAnalysis.process (package:vm/transformations/type_flow/analysis.dart:1469:14)
#48     transformComponent (package:vm/transformations/type_flow/transformer.dart:78:20)
#49     runGlobalTransformations (package:vm/kernel_front_end.dart:502:5)
#50     compileToKernel (package:vm/kernel_front_end.dart:393:11)       
<asynchronous suspension>                                               
#51     FrontendCompiler.compile.<anonymous closure> (package:frontend_server/frontend_server.dart:542:54)
#52     new Future.<anonymous closure> (dart:async/future.dart:175:37)  
#53     _rootRun (dart:async/zone.dart:1182:47)                         
#54     _CustomZone.run (dart:async/zone.dart:1093:19)                  
#55     _CustomZone.runGuarded (dart:async/zone.dart:997:7)             
#56     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1037:23)
#57     _rootRun (dart:async/zone.dart:1190:13)                         
#58     _CustomZone.run (dart:async/zone.dart:1093:19)                  
#59     _CustomZone.bindCallback.<anonymous closure> (dart:async/zone.dart:1021:23)
#60     Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:18:15)
#61     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:397:19)   
#62     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:428:5)
#63     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
```

可以看到是在`TypeFlowAnalysis.process`过程中报错，

具体报错的地方：

```
  DartType getStaticType(StaticTypeContext context) {
   ...
    return Substitution.fromPairs(
            target.function.typeParameters, arguments.types)
        .substituteType(returnType);
  }
```

因为传入`fromPairs`方法两个list参数的长度不一样，通过`Map.fromIterables`转化成Map就会报错。

因为在构建`DirectMethodInvocation`的时候,对`Argument`参数的创建有问题：

```dart
//创建DirectMethodInvocation
final DirectMethodInvocation mockedInvocation = DirectMethodInvocation(
        AsExpression(PropertyGet(ThisExpression(), Name('target')),
            InterfaceType(originalClass, Nullability.legacy)),
        originalStubProcedure,
        AopUtils.concatArguments4PointcutStubCall(originalProcedure));
        
//该方法对Arguments少了types的添加
 static Arguments concatArguments4PointcutStubCall(Member member) {
    final Arguments arguments = Arguments.empty();
     ...
      arguments.positional.add(asExpression);
      ...
      arguments.named.addAll(namedEntries);
      ...
 //缺少以下过程
    for(TypeParameter typeParameter in member.function.typeParameters){
    arguments.types.add(typeParameter.defaultType);
   }
    return arguments;
  }
```

添加`types`字段虽然能解决长度不一致的问题，但是考虑到dart-sdk目前已经删除了`DirectMethodInvocation`等类，个人认为直接修改为`MethodInvocation`更佳。
![image](https://user-images.githubusercontent.com/19933500/98650132-6fde8f80-2373-11eb-9458-66fc67c041b5.png)

若分析有误或者不足还请见谅～
